### PR TITLE
Fix JavaScript bundle TypeError

### DIFF
--- a/src/js/components/alert.js
+++ b/src/js/components/alert.js
@@ -1,6 +1,6 @@
 // Alert
 
-export const Alert = jQuery(function () {
+export function Alert() {
     // variables
     var Alert_closeBtn = $(".alert-closeable button.close");
     // function
@@ -8,4 +8,4 @@ export const Alert = jQuery(function () {
         $(this).parent().removeClass("show"); 
         $(this).parent().addClass("hide"); 
     });
-});
+};

--- a/src/js/components/btn.js
+++ b/src/js/components/btn.js
@@ -1,5 +1,5 @@
 // btn
-export const Button = jQuery(function () {
+export function Button() {
     // variables
     var btnToggle = $("[data-toggle=button]");
     // function
@@ -8,4 +8,4 @@ export const Button = jQuery(function () {
         $(this).toggleClass("active").toggleClass("focus");
     });
 
-});
+};

--- a/src/js/components/dropdown.js
+++ b/src/js/components/dropdown.js
@@ -1,4 +1,4 @@
-export const Dropdown = jQuery(function () {
+export function Dropdown() {
     // variables
     var dropBtn = $("[data-toggle=dropdown]");
     var dropContent = $(".drop-content");
@@ -10,5 +10,4 @@ export const Dropdown = jQuery(function () {
         $(this).siblings(dropContent).toggleClass('show hide');
 
     });
-
-});
+};

--- a/src/js/mine.js
+++ b/src/js/mine.js
@@ -7,6 +7,6 @@ import { Button } from "./components/btn.js";
 import { Dropdown } from "./components/dropdown.js";
 
 copyToClipboard();
-Alert();
-Button();
-Dropdown();
+jQuery(Alert);
+jQuery(Button);
+jQuery(Dropdown);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,5 +30,8 @@ module.exports = {
             jQuery: 'jquery',
             'window.jQuery': 'jquery'
         })
-    ]
+    ],
+    devServer: {
+        publicPath: '/dist/js'
+    }
 }


### PR DESCRIPTION
This is a proposed fix for issue #4 Bundle JS TypeError.

The constants exported from each of `alert.js`, `btn.js`, and `dropdown.js` were newly created references to `jQuery` objects.

The TypeError seen in the console was from attempting to invoke these new constants as if they were functions:

```js
const foo = jQuery(function() {});
foo();
// Uncaught TypeError: foo is not a function
```

I propose that the modules simply export the functions by themselves. Then, consumers of the modules are free to do whatever they wish with the functions.

Here I attempt to preserve the previous behavior; that each function is scheduled to run at document ready.

_cf._ jQuery(callback) https://api.jquery.com/jQuery/#jQuery3

Closes: #4 